### PR TITLE
v1.1

### DIFF
--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -1,7 +1,7 @@
 export class Guid {
     public static EMPTY = "00000000-0000-0000-0000-000000000000";
 
-    public static isGuid(guid: any) {
+    public static isValid(guid: any) {
         const value: string = guid.toString();
         return guid && (guid instanceof Guid || Guid.validator.test(value));
     }
@@ -29,14 +29,14 @@ export class Guid {
     private value: string = Guid.EMPTY;
 
     private constructor(guid?: string) {
-        if (guid && Guid.isGuid(guid)) {
+        if (guid && Guid.isValid(guid)) {
             this.value = guid;
         }
     }
 
     /** Compares one Guid instance with another */
     public equals(other: Guid): boolean {
-        return Guid.isGuid(other) && this.value === other.toString();
+        return Guid.isValid(other) && this.value === other.toString();
     }
 
     public isEmpty(): boolean {
@@ -45,11 +45,5 @@ export class Guid {
 
     public toString(): string {
         return this.value;
-    }
-
-    public toJSON(): any {
-        return {
-            value: this.value,
-        };
     }
 }

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -30,13 +30,13 @@ export class Guid {
 
     private constructor(guid?: string) {
         if (guid && Guid.isValid(guid)) {
-            this.value = guid;
+            this.value = guid.toLowerCase();
         }
     }
 
     /** Compares one Guid instance with another */
     public equals(other: Guid): boolean {
-        return Guid.isValid(other) && this.value === other.toString();
+        return Guid.isValid(other) && this.value === other.toString().toLowerCase();
     }
 
     public isEmpty(): boolean {

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -28,7 +28,7 @@ export class Guid {
 
     private value: string = Guid.EMPTY;
 
-    private constructor(guid?: string) {
+    constructor(guid?: string) {
         if (guid && Guid.isValid(guid)) {
             this.value = guid.toLowerCase();
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-guid",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-guid",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Easy GUID type implementation for Typescript",
   "scripts": {
     "verify": ".\\node_modules\\.bin\\tslint .\\lib\\**",
@@ -8,6 +8,11 @@
     "build": ".\\node_modules\\.bin\\tsc lib/guid -t es3 -m commonjs -d --outDir dist"
   },
   "author": "ez-libs",
+  "contributors": [
+    {"name": "NicolasDeveloper"},
+    {"name": "gekkedev"},
+    {"name": "Destinate"},
+  ],
   "keywords": [
     "typescript",
     "guid",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "contributors": [
     {"name": "NicolasDeveloper"},
     {"name": "gekkedev"},
-    {"name": "Destinate"},
+    {"name": "Destinate"}
   ],
   "keywords": [
     "typescript",

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -7,17 +7,17 @@ describe("Guid", () => {
 
     it("should create & validate a random guid", () => {
         const wrong = "wrongguid";
-        expect(Guid.isGuid(wrong)).equal(false);
+        expect(Guid.isValid(wrong)).equal(false);
 
         const right = Guid.create();
-        expect(Guid.isGuid(right)).equal(true);
+        expect(Guid.isValid(right)).equal(true);
     });
 
     it("should parse & validate a guid", () => {
         const wrong = "wrongguid";
-        expect(Guid.isGuid(wrong)).equal(false);
+        expect(Guid.isValid(wrong)).equal(false);
 
-        expect(Guid.isGuid(exampleGuid)).equal(true);
+        expect(Guid.isValid(exampleGuid)).equal(true);
     });
 
     it("should compare GUID instances to another", () => {
@@ -41,9 +41,5 @@ describe("Guid", () => {
 
     it("should create nulled GUIDs & return them as string", () => {
         expect(Guid.createEmpty().toString()).equal(Guid.EMPTY);
-    });
-
-    it("should return valid JSON", () => {
-        expect(Guid.create(exampleGuid).toJSON()).to.eql({ value: exampleGuid });
     });
 });

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -3,7 +3,7 @@ import "mocha";
 import { Guid } from "../lib/guid";
 
 describe("Guid", () => {    
-    const exampleGuid = "0315642c-a069-9f3e-1852-9adf2d075b93";
+    const exampleGuid: string = "0315642c-a069-9f3e-1852-9adf2d075b93";
 
     it("should create & validate a random guid", () => {
         const wrong = "wrongguid";
@@ -41,5 +41,11 @@ describe("Guid", () => {
 
     it("should create nulled GUIDs & return them as string", () => {
         expect(Guid.createEmpty().toString()).equal(Guid.EMPTY);
+    });
+
+    it("should not care about GUID case at all", () => {
+        const upperCaseGuid: Guid = new Guid(exampleGuid.toUpperCase());
+        const lowerCaseGuid: Guid = Guid.create(exampleGuid);
+        expect(upperCaseGuid.equals(lowerCaseGuid)).equal(true);
     });
 });

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -6,32 +6,32 @@ describe("Guid", () => {
     const exampleGuid: string = "0315642c-a069-9f3e-1852-9adf2d075b93";
 
     it("should create & validate a random guid", () => {
-        const wrong = "wrongguid";
+        const wrong: string = "wrongguid";
         expect(Guid.isValid(wrong)).equal(false);
 
-        const right = Guid.create();
+        const right: Guid = Guid.create();
         expect(Guid.isValid(right)).equal(true);
     });
 
     it("should parse & validate a guid", () => {
-        const wrong = "wrongguid";
+        const wrong: string = "wrongguid";
         expect(Guid.isValid(wrong)).equal(false);
 
         expect(Guid.isValid(exampleGuid)).equal(true);
     });
 
     it("should compare GUID instances to another", () => {
-        const wrong = Guid.create();
+        const wrong: Guid = Guid.create();
         expect(wrong.equals(Guid.create())).equal(false);
         
-        const right = Guid.create(exampleGuid);
-        const duplicate = Guid.create(exampleGuid);
+        const right: Guid = Guid.create(exampleGuid);
+        const duplicate: Guid = Guid.create(exampleGuid);
         expect(right.equals(duplicate)).equal(true);
     });
 
     it("should be unique value", () => {
-        const guids = [];
-        for (let index = 0; index < 3000; index++) {
+        const guids: Array<Guid> = [];
+        for (let index: number = 0; index < 3000; index++) {
             guids.push(Guid.create());
         }
         expect(guids.indexOf(guids[0]) < 0).equal(false);


### PR DESCRIPTION
The method toJSON() was removed because it didn't seem to be useful for most use-cases.