### PR TITLE
fixed guid validation

### DIFF
--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -3,8 +3,11 @@ export class Guid {
     public static EMPTY = "00000000-0000-0000-0000-000000000000";
     private static validator: RegExp = new RegExp("^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$", "i");
     
-    public static isValid(guid: any) {
-        const value: string = guid.toString();
+    public static isValid(guid: string | Guid) {
+        let value: string;
+        if (typeof(guid) == "string") {
+            value = (guid.indexOf("-") < 0) new Guid(guid) : guid; //if hypenated, parse it first
+        } else value = guid.toString();
         return guid && (guid instanceof Guid || this.validator.test(value));
     }
 

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -6,7 +6,7 @@ export class Guid {
     public static isValid(guid: string | Guid) {
         let value: string;
         if (typeof(guid) == "string") {
-            value = (guid.indexOf("-") < 0) ? new Guid(guid).toString() : guid; //if hypenated, parse it first
+            value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hypenated, parse it first
         } else value = guid.toString();
         return guid && (guid instanceof Guid || this.validator.test(value));
     }

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -8,7 +8,7 @@ export class Guid {
         let value: string;
         if (typeof (guid) == "string") {
             try {
-                value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hypenated, parse it first
+                value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hyphenated, parse it first
             } catch { return false }
         } else value = guid.toString();
         return guid instanceof Guid || this.validator.test(value)
@@ -42,7 +42,7 @@ export class Guid {
     /** Container for the GUID itself (in the hyphenated format). */
     private value: string = Guid.EMPTY;
 
-    /** Creates a guid object from a given Guid or, (if no parameter is given) creates one. Supported formats are: hyptenated and non-hyphenated. */
+    /** Creates a guid object from a given Guid or, (if no parameter is given) creates one. Supported formats are: hyphenated and non-hyphenated. */
     constructor(guid?: string) {
         if (guid && Guid.validator.test(guid)) { //hyphenated, no conversion necessary
             this.value = guid.toLowerCase();

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -6,7 +6,7 @@ export class Guid {
     public static isValid(guid: string | Guid): boolean {
         if (typeof (guid) == "string") {
             try {
-                value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hyphenated, parse it first
+                let value: string = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hyphenated, parse it first
                 return this.validator.test(value)
             } catch { return false }
         } else return guid instanceof Guid

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -6,7 +6,7 @@ export class Guid {
     public static isValid(guid: string | Guid) {
         let value: string;
         if (typeof(guid) == "string") {
-            value = (guid.indexOf("-") < 0) new Guid(guid) : guid; //if hypenated, parse it first
+            value = (guid.indexOf("-") < 0) ? new Guid(guid) : guid; //if hypenated, parse it first
         } else value = guid.toString();
         return guid && (guid instanceof Guid || this.validator.test(value));
     }

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -4,7 +4,6 @@ export class Guid {
     private static validator: RegExp = new RegExp("^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$", "i");
 
     public static isValid(guid: string | Guid): boolean {
-        let value: string;
         if (typeof (guid) == "string") {
             try {
                 value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hyphenated, parse it first

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -4,14 +4,13 @@ export class Guid {
     private static validator: RegExp = new RegExp("^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$", "i");
 
     public static isValid(guid: string | Guid): boolean {
-        if (guid == undefined) return false;
         let value: string;
         if (typeof (guid) == "string") {
             try {
                 value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hyphenated, parse it first
+                return this.validator.test(value)
             } catch { return false }
-        } else value = guid.toString();
-        return guid instanceof Guid || this.validator.test(value)
+        } else return guid instanceof Guid
     }
 
     /** Static alias for `new Guid()`. Refer to the constructor for further information. */

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -1,18 +1,21 @@
 export class Guid {
     /** Empty GUID string (hyphenated). */
-    public static EMPTY = "00000000-0000-0000-0000-000000000000";
+    public static EMPTY: string = "00000000-0000-0000-0000-000000000000";
     private static validator: RegExp = new RegExp("^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$", "i");
-    
-    public static isValid(guid: string | Guid) {
+
+    public static isValid(guid: string | Guid): boolean {
+        if (guid == undefined) return false;
         let value: string;
-        if (typeof(guid) == "string") {
-            value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hypenated, parse it first
+        if (typeof (guid) == "string") {
+            try {
+                value = (guid.indexOf("-") < 0) ? (new Guid(guid)).toString() : guid; //if hypenated, parse it first
+            } catch { return false }
         } else value = guid.toString();
-        return guid && (guid instanceof Guid || this.validator.test(value));
+        return guid instanceof Guid || this.validator.test(value)
     }
 
+    /** Static alias for `new Guid()`. Refer to the constructor for further information. */
     public static create(guid?: string): Guid {
-        if (!guid) guid = this.random();
         return new Guid(guid);
     }
 
@@ -39,8 +42,9 @@ export class Guid {
     /** Container for the GUID itself (in the hyphenated format). */
     private value: string = Guid.EMPTY;
 
+    /** Creates a guid object from a given Guid or, (if no parameter is given) creates one. Supported formats are: hyptenated and non-hyphenated. */
     constructor(guid?: string) {
-        if (guid && Guid.isValid(guid)) { //hyphenated, no conversion necessary
+        if (guid && Guid.validator.test(guid)) { //hyphenated, no conversion necessary
             this.value = guid.toLowerCase();
         } else if (guid && !(guid.indexOf("-") >= 0) && guid.length == 32) { //non-hyphenated
             let tempGuid: string = "";
@@ -54,7 +58,7 @@ export class Guid {
             this.value = tempGuid;
         } else if (!guid) {
             this.value = Guid.random();
-        } else throw new TypeError("No valid GUID string given; cannot instantiate!")
+        } else throw new TypeError("Invalid GUID string given; cannot instantiate!")
     }
 
     /** Compares one Guid instance with another */

--- a/lib/guid.ts
+++ b/lib/guid.ts
@@ -6,7 +6,7 @@ export class Guid {
     public static isValid(guid: string | Guid) {
         let value: string;
         if (typeof(guid) == "string") {
-            value = (guid.indexOf("-") < 0) ? new Guid(guid) : guid; //if hypenated, parse it first
+            value = (guid.indexOf("-") < 0) ? new Guid(guid).toString() : guid; //if hypenated, parse it first
         } else value = guid.toString();
         return guid && (guid instanceof Guid || this.validator.test(value));
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-guid",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-guid",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Easy GUID type implementation for Typescript",
   "scripts": {
     "verify": ".\\node_modules\\.bin\\tslint .\\lib\\**",

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -11,7 +11,6 @@ describe("Guid", () => {
         expect(Guid.isValid(wrong)).equal(false);
 
         //string
-        const dynamic_guid: Guid = new Guid();
         expect(Guid.isValid(example_hyphen)).equal(true); //valid?
         expect(Guid.isValid(example_no_hyphen)).equal(true); //non-hyphenated guid. also valid?
 

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -10,10 +10,17 @@ describe("Guid", () => {
         const wrong: string = "wrongguid";
         expect(Guid.isValid(wrong)).equal(false);
 
+        //string
+        const dynamic_guid: Guid = new Guid();
+        expect(Guid.isValid(example_hyphen)).equal(true); //valid?
+        expect(Guid.isValid(example_no_hyphen)).equal(true); //non-hyphenated guid. also valid?
+
+        //generated guid using the static construction method
         const static_guid: Guid = Guid.create();
         expect(Guid.isValid(static_guid)).equal(true); //valid?
         expect(static_guid.toString()).not.equal(Guid.EMPTY); //not null?
 
+        //generated guid using the constructor; same expectation here
         const dynamic_guid: Guid = new Guid();
         expect(Guid.isValid(dynamic_guid)).equal(true); //valid?
         expect(dynamic_guid.toString()).not.equal(Guid.EMPTY); //not null?

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -7,13 +7,6 @@ describe("Guid", () => {
     const example_no_hyphen: string = "0315642ca0699f3e18529adf2d075b93";
 
     it("should create & validate a random GUID", () => {
-        const wrong: string = "wrongguid";
-        expect(Guid.isValid(wrong)).equal(false);
-
-        //string
-        expect(Guid.isValid(example_hyphen)).equal(true); //valid?
-        expect(Guid.isValid(example_no_hyphen)).equal(true); //non-hyphenated guid. also valid?
-
         //generated guid using the static construction method
         const static_guid: Guid = Guid.create();
         expect(Guid.isValid(static_guid)).equal(true); //valid?
@@ -35,11 +28,13 @@ describe("Guid", () => {
         expect(() => new Guid(text)).to.throw(TypeError);
     });
 
-    it("should parse & validate a GUID", () => {
+    it("should parse & validate GUIDs", () => {
         const wrong: string = "wrongguid";
-        expect(Guid.isValid(wrong)).equal(false);
 
-        expect(Guid.isValid(example_hyphen)).equal(true);
+        expect(Guid.isValid(wrong)).equal(false); //must return false, no exception
+        expect(Guid.isValid(example_hyphen)).equal(true); //valid?
+        expect(Guid.isValid(example_no_hyphen)).equal(true); //non-hyphenated guid. also valid?
+        expect(Guid.isValid(example_no_hyphen + wrong)).equal(false); //valid guid plus one char. invalid?
     });
 
     it("should create nulled GUIDs & return them as a string", () => {
@@ -58,7 +53,7 @@ describe("Guid", () => {
     it("should compare GUID instances to another", () => {
         const wrong_guid: Guid = Guid.create();
         expect(wrong_guid.equals(Guid.create())).equal(false);
-        
+
         const correct_guid: Guid = Guid.create(example_hyphen);
         const duplicate_guid: Guid = Guid.create(example_hyphen);
         expect(correct_guid.equals(duplicate_guid)).equal(true);
@@ -70,7 +65,7 @@ describe("Guid", () => {
             guids.push(Guid.create());
         }
         expect(guids.indexOf(guids[0]) < 0).equal(false);
-        
+
         expect(guids.indexOf(Guid.create()) < 0).equal(true);
     });
 

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -35,6 +35,8 @@ describe("Guid", () => {
         expect(Guid.isValid(example_hyphen)).equal(true); //valid?
         expect(Guid.isValid(example_no_hyphen)).equal(true); //non-hyphenated guid. also valid?
         expect(Guid.isValid(example_no_hyphen + wrong)).equal(false); //valid guid plus one char. invalid?
+        expect(Guid.isValid(undefined)).equal(false);
+        expect(Guid.isValid(null)).equal(false);
     });
 
     it("should create nulled GUIDs & return them as a string", () => {

--- a/tests/guid.spec.ts
+++ b/tests/guid.spec.ts
@@ -35,8 +35,12 @@ describe("Guid", () => {
         expect(Guid.isValid(example_hyphen)).equal(true); //valid?
         expect(Guid.isValid(example_no_hyphen)).equal(true); //non-hyphenated guid. also valid?
         expect(Guid.isValid(example_no_hyphen + wrong)).equal(false); //valid guid plus one char. invalid?
+        //@ts-ignore
         expect(Guid.isValid(undefined)).equal(false);
+        //@ts-ignore
         expect(Guid.isValid(null)).equal(false);
+        //@ts-ignore
+        expect(Guid.isValid(123456789)).equal(false);
     });
 
     it("should create nulled GUIDs & return them as a string", () => {


### PR DESCRIPTION
With these adjustments,
- validating guid strings should be covered now without requiring to create a ´Guid´ instance
- `Guid` instantiation methods are better documented
- arguments of `isValid` are limited to strings and `Guid` instances

I recommend doing a squash merge.